### PR TITLE
Исправление бага с моком в тестах

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ db:
 	docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --name db-rating_api postgres:15
 
 migrate:
-	alembic upgrade head
+	source ./venv/bin/activate && alembic upgrade head

--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -15,7 +15,6 @@ from rating_api.exceptions import (
     ObjectNotFound,
     TooManyCommentRequests,
     TooManyCommentsToLecturer,
-    UpdateError,
 )
 from rating_api.models import Comment, Lecturer, LecturerUserComment, ReviewStatus
 from rating_api.schemas.base import StatusResponseModel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ def client(mocker):
         "id": 0,
         "email": "string",
     }
+    scopes_mock = mocker.patch('auth_lib.fastapi.UnionAuth._get_session')
+    scopes_mock.return_value = {
+        "id": 1,
+        "session_scopes": [{"name": "test_scope"}],
+        "user_scopes": [{"name": "test_scope"}]
+    }
     client = TestClient(app)
     return client
 


### PR DESCRIPTION
## Изменения
<!-- Опишите здесь на языке, понятном каждому, изменения, сделанные в исходном коде по пунктам. -->
На данный момент:
1) добавил в makefile в migrate автоматическую активацию виртуального окружения, которой почему-то не было.
2) в conftest в фикстуре client мокнул метод _get_session
## Детали реализации
<!-- Здесь можно описать технические детали по пунктам. -->
1) `migrate:
	source ./venv/bin/activate && alembic upgrade head`
2) `scopes_mock = mocker.patch('auth_lib.fastapi.UnionAuth._get_session')
    scopes_mock.return_value = {
        "id": 1,
        "session_scopes": [{"name": "test_scope"}],
        "user_scopes": [{"name": "test_scope"}]
    }`
## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
