### PR TITLE
Удаление собственного комментария

### DIFF
--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -15,7 +15,6 @@ from rating_api.exceptions import (
     ObjectNotFound,
     TooManyCommentRequests,
     TooManyCommentsToLecturer,
-    UpdateError,
 )
 from rating_api.models import Comment, CommentReaction, Lecturer, LecturerUserComment, Reaction, ReviewStatus
 from rating_api.schemas.base import StatusResponseModel
@@ -309,8 +308,11 @@ async def delete_comment(
     has_delete_scope = "rating.comment.delete" in [scope['name'] for scope in user.get('session_scopes')]
 
     # Если нет привилегии - проверяем права обычного пользователя
-    if not has_delete_scope and (comment.is_anonymous or comment.user_id != user.get('id')):
-        raise ForbiddenAction(Comment)
+    if not has_delete_scope:
+        if comment.user_id == None:
+            raise ForbiddenAction(Comment)
+        elif str(comment.user_id) != str(user.get('id')):
+            raise ForbiddenAction(Comment)
     Comment.delete(session=db.session, id=uuid)
 
     return StatusResponseModel(

--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -308,11 +308,8 @@ async def delete_comment(
     has_delete_scope = "rating.comment.delete" in [scope['name'] for scope in user.get('session_scopes')]
 
     # Если нет привилегии - проверяем права обычного пользователя
-    if not has_delete_scope:
-        if comment.user_id == None:
-            raise ForbiddenAction(Comment)
-        elif str(comment.user_id) != str(user.get('id')):
-            raise ForbiddenAction(Comment)
+    if not has_delete_scope and (comment.user_id == None or comment.user_id != user.get('id')):
+        raise ForbiddenAction(Comment)
     Comment.delete(session=db.session, id=uuid)
 
     return StatusResponseModel(


### PR DESCRIPTION
Задание: https://github.com/profcomff/rating-api/issues/134
## Изменения
<!-- Опишите здесь на языке, понятном каждому, изменения, сделанные в исходном коде по пунктам. -->
Исправил ошибку с удалением своего комментария. Раньше не имея скоупов админа нельзя было удалить свой комментарий, теперь можно.
## Детали реализации
<!-- Здесь можно описать технические детали по пунктам. -->
Все протестил при разных случаях, теперь работает. Раньше выбрасывало ошибку 500 из-за ошибки в коде эндпоинта. в структуре Comment нет is_anonymous, поэтому правильная реализация это: comment.user_id == None
Именно из-за этого все падало. А при админских правах ошибки не возникало, так как до этой части кода просто не доходило дело, она используется только обычными пользователями.
## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
