### PR TITLE
Исправлено: Для неанонимных отзывов имя пользователя запрашивается че…

### DIFF
--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -115,7 +115,7 @@ async def create_comment(
     # Обрабатываем анонимность комментария, и удаляем этот флаг чтобы добавить запись в БД
     user_id = None if comment_info.is_anonymous else user.get('id')
 
-    full_name = None
+    fullname = None
     if not comment_info.is_anonymous:
         userdata_info = user.get("userdata")
         fullname_info = list(filter(lambda x: "Полное имя" == x['param'], userdata_info))

--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -7,6 +7,7 @@ import aiohttp
 from auth_lib.fastapi import UnionAuth
 from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
+from starlette.requests import Request
 
 from rating_api.exceptions import (
     CommentTooLong,
@@ -37,7 +38,7 @@ comment = APIRouter(prefix="/comment", tags=["Comment"])
 
 
 @comment.post("", response_model=CommentGet)
-async def create_comment(lecturer_id: int, comment_info: CommentPost, user=Depends(UnionAuth())) -> CommentGet:
+async def create_comment(lecturer_id: int, comment_info: CommentPost, request: Request, user=Depends(UnionAuth())) -> CommentGet:
     """
     Scopes: `["rating.comment.create"]`
 
@@ -115,9 +116,23 @@ async def create_comment(lecturer_id: int, comment_info: CommentPost, user=Depen
 
     fullname = None
     if not comment_info.is_anonymous:
-        userdata_info = user.get("userdata", [])
-        fullname_info = list(filter(lambda x: "Полное имя" == x['param'], userdata_info))
-        fullname = fullname_info[0]["value"] if len(fullname_info) != 0 else None
+        token = request.headers.get("Authorization")
+        if token:
+            try:
+                auth = UnionAuth()
+                user_data = auth._get_userdata(token, user_id)
+                
+                if user_data and "items" in user_data:
+                    for item in user_data["items"]:
+                        if "Полное имя" in item:
+                            fullname = item["Полное имя"]
+                            break
+            except Exception:
+                pass
+
+        if not fullname:
+            raise ForbiddenAction(Comment)
+
 
     new_comment = Comment.create(
         session=db.session,

--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -38,7 +38,9 @@ comment = APIRouter(prefix="/comment", tags=["Comment"])
 
 
 @comment.post("", response_model=CommentGet)
-async def create_comment(lecturer_id: int, comment_info: CommentPost, request: Request, user=Depends(UnionAuth())) -> CommentGet:
+async def create_comment(
+    lecturer_id: int, comment_info: CommentPost, request: Request, user=Depends(UnionAuth(enable_userdata=True))
+) -> CommentGet:
     """
     Scopes: `["rating.comment.create"]`
 
@@ -113,33 +115,18 @@ async def create_comment(lecturer_id: int, comment_info: CommentPost, request: R
     )
     # Обрабатываем анонимность комментария, и удаляем этот флаг чтобы добавить запись в БД
     user_id = None if comment_info.is_anonymous else user.get('id')
-
-    fullname = None
+    full_name = None
     if not comment_info.is_anonymous:
-        token = request.headers.get("Authorization")
-        if token:
-            try:
-                auth = UnionAuth()
-                user_data = auth._get_userdata(token, user_id)
-                
-                if user_data and "items" in user_data:
-                    for item in user_data["items"]:
-                        if "Полное имя" in item:
-                            fullname = item["Полное имя"]
-                            break
-            except Exception:
-                pass
-
-        if not fullname:
-            raise ForbiddenAction(Comment)
-
+        userdata_info = user.get("userdata")
+        full_name_info = list(filter(lambda x: "Полное имя" == x['param'], userdata_info))
+        full_name = full_name_info[0]["value"] if len(full_name_info) != 0 else None
 
     new_comment = Comment.create(
         session=db.session,
         **comment_info.model_dump(exclude={"is_anonymous"}),
         lecturer_id=lecturer_id,
         user_id=user_id,
-        user_fullname=fullname,
+        user_fullname=full_name,
         review_status=ReviewStatus.PENDING,
     )
 

--- a/rating_api/routes/comment.py
+++ b/rating_api/routes/comment.py
@@ -7,7 +7,6 @@ import aiohttp
 from auth_lib.fastapi import UnionAuth
 from fastapi import APIRouter, Depends, Query
 from fastapi_sqlalchemy import db
-from starlette.requests import Request
 
 from rating_api.exceptions import (
     CommentTooLong,
@@ -39,7 +38,7 @@ comment = APIRouter(prefix="/comment", tags=["Comment"])
 
 @comment.post("", response_model=CommentGet)
 async def create_comment(
-    lecturer_id: int, comment_info: CommentPost, request: Request, user=Depends(UnionAuth(enable_userdata=True))
+    lecturer_id: int, comment_info: CommentPost, user=Depends(UnionAuth(enable_userdata=True))
 ) -> CommentGet:
     """
     Scopes: `["rating.comment.create"]`
@@ -115,18 +114,19 @@ async def create_comment(
     )
     # Обрабатываем анонимность комментария, и удаляем этот флаг чтобы добавить запись в БД
     user_id = None if comment_info.is_anonymous else user.get('id')
+
     full_name = None
     if not comment_info.is_anonymous:
         userdata_info = user.get("userdata")
-        full_name_info = list(filter(lambda x: "Полное имя" == x['param'], userdata_info))
-        full_name = full_name_info[0]["value"] if len(full_name_info) != 0 else None
+        fullname_info = list(filter(lambda x: "Полное имя" == x['param'], userdata_info))
+        fullname = fullname_info[0]["value"] if len(fullname_info) != 0 else None
 
     new_comment = Comment.create(
         session=db.session,
         **comment_info.model_dump(exclude={"is_anonymous"}),
         lecturer_id=lecturer_id,
         user_id=user_id,
-        user_fullname=full_name,
+        user_fullname=fullname,
         review_status=ReviewStatus.PENDING,
     )
 


### PR DESCRIPTION
…рез UnionAuth._get_userdata. Если в профиле не задано имя, то возвращается ошибка, отзыв не создаётся

## Изменения
1. Исправлена ошибка, из-за которой у неанонимных отзывов поле user_fullname заполнялось как null
 (UnionAuth не отправляет имя пользователя в userdata, а код искал его именно там. В результате значение всегда оставалось null)

3. Теперь имя пользователя запрашивается через UnionAuth._get_userdata

4. Если в профиле пользователя не задано имя, то возвращается ошибка, отзыв не создаётся

## Детали реализации
1. В функцию create_comment добавлен параметр request: Request для получения токена из Authorization

2. Добавлен вызов auth._get_userdata(token, user_id) для получения полных данных пользователя из Auth API

3. Имя извлекается из поля "Полное имя"

4. Если имя не найдено, то вызывается ForbiddenAction